### PR TITLE
Fix Terraform Github Action Workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -2,9 +2,13 @@ name: 'Terraform'
 
 on:
   push:
+    paths:
+    - 'config/terraform/aws'
     branches:
     - master
   pull_request:
+    paths:
+    - 'config/terraform/aws'
 
 defaults:
   run:
@@ -20,8 +24,9 @@ env:
   TF_VAR_rds_backend_db_password: ${{ secrets.TF_VAR_rds_backend_db_password }}
 
 jobs:
-  terraform:
+  terraform-plan:
     name: 'Terraform'
+    if: github.repository_owner == 'CovidShield'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -38,7 +43,25 @@ jobs:
 
     - name: Terraform Plan
       run: terraform plan
+  terraform-apply:
+    name: 'Terraform'
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push' && github.repository_owner == 'CovidShield'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+
+    - name: Terraform Init
+      run: terraform init
+
+    - name: Terraform Format
+      run: terraform fmt -check
+
+    - name: Terraform Plan
+      run: terraform plan -out terraform.tfplan
 
     - name: Terraform Apply
-      if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-      run: terraform apply -auto-approve
+      run: terraform apply -auto-approve terraform.tfplan

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,7 +25,6 @@ env:
 
 jobs:
   terraform-plan:
-    name: 'Terraform'
     if: github.repository_owner == 'CovidShield'
     runs-on: ubuntu-latest
     steps:
@@ -43,8 +42,8 @@ jobs:
 
     - name: Terraform Plan
       run: terraform plan
+
   terraform-apply:
-    name: 'Terraform'
     if: github.ref == 'refs/heads/master' && github.event_name == 'push' && github.repository_owner == 'CovidShield'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -48,7 +48,16 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push' && github.repository_owner == 'CovidShield'
     runs-on: ubuntu-latest
     steps:
+    - name: Wait for container to be built and pushed
+      uses: fountainhead/action-wait-for-check@v1.0.0
+      id: wait-for-build
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        checkName: build-n-push
+        ref: ${{ github.sha }}
+
     - name: Checkout
+      if: steps.wait-for-build.outputs.conclusion == 'success'
       uses: actions/checkout@v2
 
     - name: Setup Terraform

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -3,12 +3,12 @@ name: 'Terraform'
 on:
   push:
     paths:
-    - 'config/terraform/aws'
+    - 'config/terraform/aws/*'
     branches:
     - master
   pull_request:
     paths:
-    - 'config/terraform/aws'
+    - 'config/terraform/aws/*'
 
 defaults:
   run:

--- a/config/terraform/aws/networking.tf
+++ b/config/terraform/aws/networking.tf
@@ -36,7 +36,7 @@ resource "aws_subnet" "covidshield_private" {
   count = 3
 
   vpc_id            = aws_vpc.covidshield.id
-  cidr_block        = cidrsubnet("10.0.0.0/16", 8, count.index)
+  cidr_block        = cidrsubnet(var.vpc_cidr_block, 8, count.index)
   availability_zone = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
@@ -49,7 +49,7 @@ resource "aws_subnet" "covidshield_public" {
   count = 3
 
   vpc_id            = aws_vpc.covidshield.id
-  cidr_block        = cidrsubnet("10.0.0.0/16", 8, count.index + 3)
+  cidr_block        = cidrsubnet(var.vpc_cidr_block, 8, count.index + 3)
   availability_zone = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
@@ -184,21 +184,21 @@ resource "aws_security_group" "covidshield_load_balancer" {
     protocol    = "tcp"
     from_port   = 8001
     to_port     = 8001
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = [var.vpc_cidr_block]
   }
 
   egress {
     protocol    = "tcp"
     from_port   = 8000
     to_port     = 8000
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = [var.vpc_cidr_block]
   }
 
   egress {
     protocol    = "tcp"
     from_port   = 3000
     to_port     = 3000
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = [var.vpc_cidr_block]
   }
 
   tags = {


### PR DESCRIPTION
* Adds a path filter to ensure the action only runs when it needs to
* Prevent the action from running on forks (they don't have access to the GH secrets to properly run it anyway)
* When applying: 
  * Wait for the containers to be built and pushed to ECR before running the action
  * Apply the tfplan generated by the previous step