### PR TITLE
Improve deployment logic

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   terraform-plan:
-    if: github.repository_owner == 'CovidShield'
+    if: github.ref != 'refs/heads/master' && github.repository_owner == 'CovidShield'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -67,7 +67,11 @@ jobs:
       run: terraform fmt -check
 
     - name: Terraform Plan
+      env:
+        TF_VAR_github_sha: ${{ github.sha }}
       run: terraform plan -out terraform.tfplan
 
     - name: Terraform Apply
+      env:
+        TF_VAR_github_sha: ${{ github.sha }}
       run: terraform apply -auto-approve terraform.tfplan

--- a/config/terraform/aws/provider.tf
+++ b/config/terraform/aws/provider.tf
@@ -3,6 +3,11 @@ provider "aws" {
   region  = var.region
 }
 
+provider "github" {
+  organization = "CovidShield"
+  anonymous    = true
+}
+
 terraform {
   required_version = "> 0.12.0"
 }

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -23,6 +23,11 @@ variable "cloudwatch_log_group_name" {
 ###
 # AWS ECS - ecs.tf
 ###
+variable "github_sha" {
+  type    = string
+  default = ""
+}
+
 variable "ecs_name" {
   type = string
 }


### PR DESCRIPTION
* Terraform will now use commit SHAs to reference containers
* Allow Fargate to roll containers when a new task definition is brought up
* Prevent `terraform-plan` GH action from running on master branch (not necessary since `terraform-apply` is going to run)
