### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The published _Diagnosis Keys_ are fetched—with some best-effort authenticatio
 Distribution Network (CDN), backed by `key-retrieval`. This allows a functionally-arbitrary number
 of concurrent users.
 
-### Retreiving Exposure Configuration
+### Retrieving Exposure Configuration
 
 [_Exposure Configuration_](https://developer.apple.com/documentation/exposurenotification/enexposureconfiguration),
 used to determine the risk of a given exposure, is also retrieved from the `key-retieval` server. A JSON

--- a/config/infrastructure/aws/README.md
+++ b/config/infrastructure/aws/README.md
@@ -2,7 +2,7 @@
 
 :warning: This is not a fully featured production environment and aims to provide an accesible overview of the service.
 
-This document describes how to deploy and operate a **reference implmentation** of the Covid Shield web portal, along with the diagnosis key retrieval and submission services on [AWS](https://aws.amazon.com/).
+This document describes how to deploy and operate a **reference implementation** of the Covid Shield web portal, along with the diagnosis key retrieval and submission services on [AWS](https://aws.amazon.com/).
 
 There should be an illustration of the Covid Shield infrastructure deployed on AWS right here
 

--- a/examples/new-key-claim/readme.md
+++ b/examples/new-key-claim/readme.md
@@ -1,6 +1,6 @@
 # Examples
 
-Recieving a new key is a simple HTTP call to the backend with an Authentication header. This should be straightforward to implement as part of any public health worker system. Please note to keep the authentication token secret and avoid exposing generated keys to people who have not have had COVID positive test results
+Receiving a new key is a simple HTTP call to the backend with an Authentication header. This should be straightforward to implement as part of any public health worker system. Please note to keep the authentication token secret and avoid exposing generated keys to people who have not have had COVID positive test results
 
 
 ```sh

--- a/examples/retrieval/README.md
+++ b/examples/retrieval/README.md
@@ -1,4 +1,4 @@
 # retrieval example
 
-This is an example implmentation of a client for the `key-retrieval` service, correctly implementing
+This is an example implementation of a client for the `key-retrieval` service, correctly implementing
 incremental fetching and caching.


### PR DESCRIPTION
Hey,

This tiny PR will fix : 

- 1 typo in `README.md`
- 1 typo in `config/infrastructure/aws/README.md`
- 1 typo in `examples/new-key-claim/readme.md`
- 1 typo in `examples/retrieval/README.md`



Ciao! :robot: